### PR TITLE
Fix Shodan API error display

### DIFF
--- a/kamerka.py
+++ b/kamerka.py
@@ -54,7 +54,7 @@ def shodan_query(query):
     try:
         result = api.search(query)
     except shodan.APIError as e:
-        print e.message
+        print('Error: {}'.format(e))
         sys.exit()
 
     if len(result['matches']) > 0:


### PR DESCRIPTION
I've had no error displayed when running the program with a wrong API key. It seems that the correct way to display the API error message is to directly print the shodan.APIError as proposed in my pull request.